### PR TITLE
Custom activity table view cell changes

### DIFF
--- a/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit.xcodeproj/project.pbxproj
@@ -173,6 +173,8 @@
 		FC9047CE21E5626D0012C685 /* CustomActivityTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FC9047CC21E5626D0012C685 /* CustomActivityTableViewCell.m */; };
 		FC9047E721E5A1890012C685 /* CustomSectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = FC9047E521E5A1890012C685 /* CustomSectionView.h */; };
 		FC9047E821E5A1890012C685 /* CustomSectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = FC9047E621E5A1890012C685 /* CustomSectionView.m */; };
+		FCE629F121EBE40600D541A9 /* CustomSegmentedControlSection.h in Headers */ = {isa = PBXBuildFile; fileRef = FCE629EF21EBE40600D541A9 /* CustomSegmentedControlSection.h */; };
+		FCE629F221EBE40600D541A9 /* CustomSegmentedControlSection.m in Sources */ = {isa = PBXBuildFile; fileRef = FCE629F021EBE40600D541A9 /* CustomSegmentedControlSection.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -386,6 +388,8 @@
 		FC9047CC21E5626D0012C685 /* CustomActivityTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomActivityTableViewCell.m; sourceTree = "<group>"; };
 		FC9047E521E5A1890012C685 /* CustomSectionView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomSectionView.h; sourceTree = "<group>"; };
 		FC9047E621E5A1890012C685 /* CustomSectionView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomSectionView.m; sourceTree = "<group>"; };
+		FCE629EF21EBE40600D541A9 /* CustomSegmentedControlSection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomSegmentedControlSection.h; sourceTree = "<group>"; };
+		FCE629F021EBE40600D541A9 /* CustomSegmentedControlSection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomSegmentedControlSection.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -894,6 +898,8 @@
 			children = (
 				FC9047E521E5A1890012C685 /* CustomSectionView.h */,
 				FC9047E621E5A1890012C685 /* CustomSectionView.m */,
+				FCE629EF21EBE40600D541A9 /* CustomSegmentedControlSection.h */,
+				FCE629F021EBE40600D541A9 /* CustomSegmentedControlSection.m */,
 			);
 			name = "Section Views";
 			sourceTree = "<group>";
@@ -971,6 +977,7 @@
 				8677EE101C9775EB00588CD6 /* OCKCarePlanActivity_Internal.h in Headers */,
 				BA274F471EB703DC00DD17EF /* OCKTextView.h in Headers */,
 				8677EE141C9775EB00588CD6 /* OCKCarePlanEventResult.h in Headers */,
+				FCE629F121EBE40600D541A9 /* CustomSegmentedControlSection.h in Headers */,
 				2489297B1C90E70100EBBE1F /* OCKConnectTableViewHeader.h in Headers */,
 				BA3793D81EB66BC50004A540 /* OCKPatientWidget.h in Headers */,
 				BA3793E81EB66D7D0004A540 /* OCKDefaultPatientWidgetView.h in Headers */,
@@ -1158,6 +1165,7 @@
 				244A924A1CA210F7007B42D6 /* OCKWeekViewController.m in Sources */,
 				241707CA1C9A3AB7005D7123 /* OCKChart.m in Sources */,
 				BA38457F1D9CA698007990DA /* OCKGlyph.m in Sources */,
+				FCE629F221EBE40600D541A9 /* CustomSegmentedControlSection.m in Sources */,
 				24FD43741E56843E004439EA /* OCKConnectHeaderView.m in Sources */,
 				8677EE191C9775EB00588CD6 /* OCKCarePlanStore.xcdatamodeld in Sources */,
 				241707D01C9A3AB7005D7123 /* OCKGroupedBarChartView.m in Sources */,

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -127,8 +127,8 @@
     self.store.careCardUIDelegate = self;
     [self setGlyphTintColor: _glyphTintColor];
     NSDictionary *_initialDictionary = @{ @(OCKCarePlanActivityTypeAssessment): [NSMutableArray new],
-                                         @(OCKCarePlanActivityTypeIntervention): [NSMutableArray new],
-                                         @(OCKCarePlanActivityTypeReadOnly): [NSMutableArray new],
+                                          @(OCKCarePlanActivityTypeIntervention): [NSMutableArray new],
+                                          @(OCKCarePlanActivityTypeReadOnly): [NSMutableArray new],
                                           @(OCKCarePlanActivityTypeHealthEntry): [NSMutableArray new],
                                           @(OCKCarePlanActivityTypeNonPrescribedTrackables): [NSMutableArray new],
                                           @(OCKCarePlanActivityTypeButton): [NSMutableArray new]
@@ -759,8 +759,8 @@
                         OCKCareCardTableViewCell *cell = [_tableView cellForRowAtIndexPath:indexPath];
                         cell.interventionEvents = events;
                     } else if (type == OCKCarePlanActivityTypeAssessment) {
-                        OCKSymptomTrackerTableViewCell *cell = [_tableView cellForRowAtIndexPath:indexPath];
-                        cell.assessmentEvent = events.firstObject;
+                        CustomActivityTableViewCell *cell = [_tableView cellForRowAtIndexPath:indexPath];
+                        cell.event = events.firstObject;
                     }
                 }
                 break;
@@ -900,7 +900,6 @@
                                                          reuseIdentifier:CellIdentifier];
         }
         cell.event = event;
-        cell.cellBackgroundColor = [UIColor purpleColor];
         
         return cell;
     }
@@ -913,7 +912,6 @@
                                                       reuseIdentifier:CellIdentifier];
         }
         cell.event = event;
-        cell.cellBackgroundColor = [UIColor purpleColor];
 
         return cell;
     }

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -862,6 +862,8 @@
         } else {
             sectionView.subtitle = _nonPrescribedTrackablesEmptySectionSubheaderString;
         }
+    } else {
+        sectionView.subtitle = @"";
     }
 
     return sectionView;
@@ -950,6 +952,7 @@
         }
         cell.textLabel.text = event.activity.title;
         cell.detailTextLabel.text = event.activity.text;
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 
         return cell;
     }

--- a/CareKit/CareContents/OCKCareContentsViewController.m
+++ b/CareKit/CareContents/OCKCareContentsViewController.m
@@ -47,6 +47,7 @@
 #import "OCKGlyph_Internal.h"
 #import "CustomActivityTableViewCell.h"
 #import "CustomSectionView.h"
+#import "CustomSegmentedControlSection.h"
 
 
 #define RedColor() OCKColorFromRGB(0xEF445B);
@@ -845,28 +846,36 @@
 #pragma mark - UITableViewDelegate
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
-    NSString *HeaderIdentifier = @"DefaultSection";
-    CustomSectionView *sectionView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:HeaderIdentifier];
-    if (!sectionView) {
-        sectionView = [[CustomSectionView alloc] initWithReuseIdentifier:HeaderIdentifier];
-    }
-
-    NSString *sectionTitle = _sectionTitles[section];
-    sectionView.title = sectionTitle;
 
     OCKCarePlanEvent *selectedEvent = _tableViewData[section].firstObject.firstObject;
     OCKCarePlanActivityType type = selectedEvent.activity.type;
+    NSString *sectionTitle = _sectionTitles[section];
+
     if (type == OCKCarePlanActivityTypeNonPrescribedTrackables) {
+        NSString *HeaderIdentifier = @"NonPrescribedTrackablesSection";
+        CustomSegmentedControlSection *sectionView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:HeaderIdentifier];
+        if (!sectionView) {
+            sectionView = [[CustomSegmentedControlSection alloc] initWithReuseIdentifier:HeaderIdentifier];
+        }
+        
+        sectionView.title = sectionTitle;
         if (_tableViewData[section].count > 0) {
             sectionView.subtitle = _nonPrescribedTrackablesSectionSubheaderString;
         } else {
             sectionView.subtitle = _nonPrescribedTrackablesEmptySectionSubheaderString;
         }
+        return sectionView;
     } else {
-        sectionView.subtitle = @"";
+        NSString *HeaderIdentifier = @"DefaultSection";
+        CustomSectionView *sectionView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:HeaderIdentifier];
+        if (!sectionView) {
+            sectionView = [[CustomSectionView alloc] initWithReuseIdentifier:HeaderIdentifier];
+        }
+        sectionView.title = sectionTitle;
+        return sectionView;
     }
 
-    return sectionView;
+
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/CareKit/CarePlan/OCKCarePlanActivity.h
+++ b/CareKit/CarePlan/OCKCarePlanActivity.h
@@ -188,13 +188,14 @@ OCK_CLASS_AVAILABLE
  */
 
 + (instancetype)healthDataEntryWithIdentifier:(NSString *)identifier
-                             groupIdentifier:(nullable NSString *)groupIdentifier
-                                       title:(NSString *)title
-                                        text:(nullable NSString *)text
-                                instructions:(nullable NSString *)instructions
-                                    imageURL:(nullable NSURL *)imageURL
-                                    schedule:(OCKCareSchedule *)schedule
-                                    userInfo:(nullable NSDictionary *)userInfo;
+                              groupIdentifier:(nullable NSString *)groupIdentifier
+                                        title:(NSString *)title
+                                         text:(nullable NSString *)text
+                                    tintColor:(UIColor *)tintColor
+                                 instructions:(nullable NSString *)instructions
+                                     imageURL:(nullable NSURL *)imageURL
+                                     schedule:(OCKCareSchedule *)schedule
+                                     userInfo:(nullable NSDictionary *)userInfo;
 
 /**
  Convenience initializer for track button related activity type

--- a/CareKit/CarePlan/OCKCarePlanActivity.m
+++ b/CareKit/CarePlan/OCKCarePlanActivity.m
@@ -214,23 +214,25 @@
                               groupIdentifier:(nullable NSString *)groupIdentifier
                                         title:(NSString *)title
                                          text:(nullable NSString *)text
+                                    tintColor:(UIColor *)tintColor
                                  instructions:(nullable NSString *)instructions
                                      imageURL:(nullable NSURL *)imageURL
                                      schedule:(OCKCareSchedule *)schedule
                                      userInfo:(nullable NSDictionary *)userInfo {
+
     return [[self alloc] initWithIdentifier:identifier
-                            groupIdentifier:groupIdentifier
-                                       type:OCKCarePlanActivityTypeHealthEntry
-                                      title:title
-                                       text:text
-                                  tintColor:nil
-                               instructions:instructions
-                                   imageURL:imageURL
-                                   schedule:schedule
-                           resultResettable:NO
-                                   userInfo:userInfo
-                                 thresholds:nil
-                                   optional:YES];
+                                  groupIdentifier:groupIdentifier
+                                             type:OCKCarePlanActivityTypeHealthEntry
+                                            title:title
+                                             text:text
+                                        tintColor:tintColor
+                                     instructions:nil
+                                         imageURL:nil
+                                         schedule:schedule
+                                 resultResettable:NO
+                                         userInfo:userInfo
+                                       thresholds:nil
+                                         optional:YES];
 }
 
 + (instancetype)buttonWithIdentifier:(NSString *)identifier

--- a/CareKit/Common/CustomActivityTableViewCell.h
+++ b/CareKit/Common/CustomActivityTableViewCell.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CustomActivityTableViewCell : OCKTableViewCell
 
 @property (nonatomic, copy) OCKCarePlanEvent *event;
-@property (nonatomic, copy) UIColor *cellBackgroundColor;
 
 @end
 

--- a/CareKit/Common/CustomActivityTableViewCell.m
+++ b/CareKit/Common/CustomActivityTableViewCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "OCKLabel.h"
+#import "OCKHelpers.h"
 #import "CustomActivityTableViewCell.h"
 
 static const CGFloat TopMargin = 5.0;
@@ -19,12 +20,6 @@ static const CGFloat HorizontalMargin = 5.0;
     OCKLabel *_updatedAtLabel;
     UIView *_roundedView;
     NSMutableArray *_constraints;
-}
-
-- (void)setCellBackgroundColor:(UIColor *)cellBackgroundColor {
-    if (_roundedView) {
-        _roundedView.backgroundColor = cellBackgroundColor;
-    }
 }
 
 - (void)setEvent:(OCKCarePlanEvent *)event {
@@ -40,6 +35,7 @@ static const CGFloat HorizontalMargin = 5.0;
         _roundedView = [UIView new];
         _roundedView.layer.cornerRadius = 5.0;
         _roundedView.layer.masksToBounds = YES;
+        _roundedView.backgroundColor = _event.activity.tintColor;
         [self.contentView addSubview:_roundedView];
     }
 
@@ -70,10 +66,34 @@ static const CGFloat HorizontalMargin = 5.0;
     [self setUpConstraints];
 }
 
+- (NSAttributedString *)attributedStringFromResult:(OCKCarePlanEventResult *) result {
+    NSMutableParagraphStyle *paragraphStyle = NSMutableParagraphStyle.new;
+    paragraphStyle.alignment = NSTextAlignmentRight;
+    NSDictionary *resultStringAttributes = @{ NSParagraphStyleAttributeName: paragraphStyle };
+    NSMutableAttributedString *resultString = [[NSMutableAttributedString alloc] initWithString:@"" attributes: resultStringAttributes];
+
+    NSDictionary *valueStringAttributes = @{ NSFontAttributeName: [UIFont systemFontOfSize:49 weight:UIFontWeightRegular] };
+    NSAttributedString *valueString = [[NSAttributedString alloc] initWithString:result.valueString attributes: valueStringAttributes];
+    [resultString appendAttributedString: valueString];
+
+    NSDictionary *unitStringAttributes = @{ NSFontAttributeName: [UIFont systemFontOfSize:20 weight:UIFontWeightMedium] };
+    NSAttributedString *unitString = [[NSAttributedString alloc] initWithString: result.unitString attributes: unitStringAttributes];
+    [resultString appendAttributedString:unitString];
+
+    return resultString;
+}
+
 - (void)updateView {
     _titleLabel.text = _event.activity.title;
-    _valueLabel.text = _event.result.valueString;
-    _updatedAtLabel.text = _event.activity.text;
+
+    if (_event.state == OCKCarePlanEventStateCompleted) {
+        _valueLabel.attributedText = [self attributedStringFromResult:_event.result];
+        NSString *updatedAt = OCKShortStyleTimeStringFromDate(_event.result.creationDate);
+        _updatedAtLabel.text = [NSString stringWithFormat:@"Today at %@", updatedAt];
+    } else {
+        _updatedAtLabel.text = @"NOT COMPLETED";
+    }
+
 }
 
 - (void)setUpConstraints {

--- a/CareKit/Common/CustomSectionView.m
+++ b/CareKit/Common/CustomSectionView.m
@@ -36,6 +36,7 @@
 
     _subtitleLabel = [OCKLabel new];
     _subtitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    _subtitleLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
     _subtitleLabel.numberOfLines = 0;
     [self.contentView addSubview:_subtitleLabel];
 }
@@ -54,7 +55,7 @@
     _constraints = [NSMutableArray arrayWithArray: @[
                                                      // Title Label
                                                      [NSLayoutConstraint constraintWithItem:_titleLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeTop multiplier:1.0 constant:25.0],
-                                                     [NSLayoutConstraint constraintWithItem:_titleLabel attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeLeading multiplier:1.0 constant:15.0],
+                                                     [NSLayoutConstraint constraintWithItem:_titleLabel attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeLeading multiplier:1.0 constant:20.0],
                                                      [NSLayoutConstraint constraintWithItem:_titleLabel attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:-15.0],
                                                      // Subtitle Label
                                                      [NSLayoutConstraint constraintWithItem: _subtitleLabel

--- a/CareKit/Common/CustomSegmentedControlSection.h
+++ b/CareKit/Common/CustomSegmentedControlSection.h
@@ -1,0 +1,20 @@
+//
+//  CustomSegmentedControlSection.h
+//  CareKit
+//
+//  Created by Damian Dara on 14/1/19.
+//  Copyright © 2019 carekit.org. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CustomSegmentedControlSection : UITableViewHeaderFooterView
+
+@property (copy, nonatomic) NSString *title;
+@property (copy, nonatomic) NSString *subtitle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CareKit/Common/CustomSegmentedControlSection.m
+++ b/CareKit/Common/CustomSegmentedControlSection.m
@@ -1,0 +1,142 @@
+//
+//  CustomSegmentedControlSection.m
+//  CareKit
+//
+//  Created by Damian Dara on 14/1/19.
+//  Copyright © 2019 carekit.org. All rights reserved.
+//
+
+#import "OCKLabel.h"
+#import "CustomSegmentedControlSection.h"
+
+@implementation CustomSegmentedControlSection {
+    OCKLabel *_titleLabel;
+    OCKLabel *_subtitleLabel;
+    UISegmentedControl *_segmentedControl;
+    NSMutableArray<NSLayoutConstraint *> *_constraints;
+}
+
+- (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithReuseIdentifier:reuseIdentifier];
+    if (self) {
+        [self initViews];
+        [self initConstraints];
+    }
+    return self;
+}
+
+- (void)initViews {
+    UIView *backgroundView = [UIView new];
+    backgroundView.backgroundColor = [UIColor whiteColor];
+    self.backgroundView = backgroundView;
+
+    _titleLabel = [OCKLabel new];
+    _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    _titleLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightBold];
+    _titleLabel.numberOfLines = 0;
+    [self.contentView addSubview:_titleLabel];
+
+    _subtitleLabel = [OCKLabel new];
+    _subtitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    _subtitleLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightRegular];
+    _subtitleLabel.numberOfLines = 0;
+    [self.contentView addSubview:_subtitleLabel];
+
+    _segmentedControl = [[UISegmentedControl alloc] initWithItems: @[ @"My Health", @"My Symptoms" ]];
+    _segmentedControl.translatesAutoresizingMaskIntoConstraints = NO;
+    _segmentedControl.selectedSegmentIndex = 0;
+    [self.contentView addSubview:_segmentedControl];
+}
+
+- (void)setTitle:(NSString *)title {
+    _title = title;
+    _titleLabel.text = _title;
+}
+
+- (void)setSubtitle:(NSString *)subtitle {
+    _subtitle = subtitle;
+    _subtitleLabel.text = _subtitle;
+}
+
+- (void)initConstraints {
+    _constraints = [NSMutableArray arrayWithArray: @[
+                                                     // Title Label
+                                                     [NSLayoutConstraint constraintWithItem:_titleLabel
+                                                                                  attribute:NSLayoutAttributeTop
+                                                                                  relatedBy:NSLayoutRelationEqual
+                                                                                     toItem:self.contentView
+                                                                                  attribute:NSLayoutAttributeTop
+                                                                                 multiplier:1.0
+                                                                                   constant:25.0],
+                                                     [NSLayoutConstraint constraintWithItem:_titleLabel
+                                                                                  attribute:NSLayoutAttributeLeading
+                                                                                  relatedBy:NSLayoutRelationEqual
+                                                                                     toItem:self.contentView
+                                                                                  attribute:NSLayoutAttributeLeading
+                                                                                 multiplier:1.0
+                                                                                   constant:20.0],
+                                                     [NSLayoutConstraint constraintWithItem:_titleLabel
+                                                                                  attribute:NSLayoutAttributeTrailing
+                                                                                  relatedBy:NSLayoutRelationEqual
+                                                                                     toItem:self.contentView
+                                                                                  attribute:NSLayoutAttributeTrailing
+                                                                                 multiplier:1.0
+                                                                                   constant:-15.0],
+                                                     // Subtitle Label
+                                                     [NSLayoutConstraint constraintWithItem: _subtitleLabel
+                                                                                  attribute: NSLayoutAttributeTop
+                                                                                  relatedBy: NSLayoutRelationEqual
+                                                                                     toItem: _titleLabel
+                                                                                  attribute: NSLayoutAttributeBottom
+                                                                                 multiplier: 1.0
+                                                                                   constant: 5.0],
+                                                     [NSLayoutConstraint constraintWithItem: _subtitleLabel
+                                                                                  attribute: NSLayoutAttributeTrailing
+                                                                                  relatedBy: NSLayoutRelationEqual
+                                                                                     toItem: _titleLabel
+                                                                                  attribute: NSLayoutAttributeTrailing
+                                                                                 multiplier: 1.0
+                                                                                   constant: 0.0],
+                                                     [NSLayoutConstraint constraintWithItem: _subtitleLabel
+                                                                                  attribute: NSLayoutAttributeLeading
+                                                                                  relatedBy: NSLayoutRelationEqual
+                                                                                     toItem: _titleLabel
+                                                                                  attribute: NSLayoutAttributeLeading
+                                                                                 multiplier: 1.0
+                                                                                   constant: 0.0],
+                                                     [NSLayoutConstraint constraintWithItem: _subtitleLabel
+                                                                                  attribute: NSLayoutAttributeBottom
+                                                                                  relatedBy: NSLayoutRelationEqual
+                                                                                     toItem: _segmentedControl
+                                                                                  attribute: NSLayoutAttributeTop
+                                                                                 multiplier: 1.0
+                                                                                   constant: -7.0],
+                                                     // Segmented control
+                                                     [NSLayoutConstraint constraintWithItem:_segmentedControl
+                                                                                  attribute:NSLayoutAttributeLeading
+                                                                                  relatedBy:NSLayoutRelationEqual
+                                                                                     toItem:_titleLabel
+                                                                                  attribute:NSLayoutAttributeLeading
+                                                                                 multiplier:1.0
+                                                                                   constant: 0.0],
+                                                     [NSLayoutConstraint constraintWithItem:_segmentedControl
+                                                                                  attribute:NSLayoutAttributeTrailing
+                                                                                  relatedBy:NSLayoutRelationEqual
+                                                                                     toItem:_titleLabel
+                                                                                  attribute:NSLayoutAttributeTrailing
+                                                                                 multiplier:1.0
+                                                                                   constant:0.0],
+                                                     [NSLayoutConstraint constraintWithItem: _segmentedControl
+                                                                                  attribute: NSLayoutAttributeBottom
+                                                                                  relatedBy: NSLayoutRelationEqual
+                                                                                     toItem: self.contentView
+                                                                                  attribute: NSLayoutAttributeBottom
+                                                                                 multiplier: 1.0
+                                                                                   constant: -7.0]
+                                                     ]
+                    ];
+    [NSLayoutConstraint activateConstraints:_constraints];
+}
+
+@end
+

--- a/CareKit/Localization/en.lproj/CareKit.strings
+++ b/CareKit/Localization/en.lproj/CareKit.strings
@@ -34,9 +34,10 @@
 "ACTIVITY_TYPE_OPTIONAL_SECTION_HEADER" = "Optional";
 "ACTIVITY_TYPE_READ_ONLY_SECTION_HEADER" = "Read Only";
 "ACTIVITY_TYPE_HEALTH_DATA_SECTION_HEADER" = "Device Health Data";
-"ACTIVITY_TYPE_BUTTON_SECTION_HEADER" = "";
+"ACTIVITY_TYPE_BUTTON_SECTION_HEADER" = "Test";
 "ACTIVITY_TYPE_NON_PRESCRIBED_TRACKABLE_SECTION_HEADER" = "Non-prescribed Trackables";
-"ACTIVITY_TYPE_NON_PRESCRIBED_TRACKABLE_SECTION_SUBHEADER" = "These are items not prescribed by your clinician but recorded by you in the My Health and My Treatment sections. You have NO non-prescribed trackables for today.";
+"ACTIVITY_TYPE_NON_PRESCRIBED_TRACKABLE_SECTION_SUBHEADER" = "These are items not prescribed by your clinician but recorded by you in the My Health and My Treatment sections.";
+"ACTIVITY_TYPE_NON_PRESCRIBED_TRACKABLE_EMPTY_SECTION_SUBHEADER" = "These are items not prescribed by your clinician but recorded by you in the My Health and My Treatment sections. You have NO non-prescribed trackables for today.";
 "HEADER_TITLE_CARE_OVERVIEW" = "Your care overview is %@ complete";
 "HEADER_TITLE_ACTIVITY_STATUS" = "Your activity status is %@ complete";
 

--- a/CareKit/Utilities/OCKHelpers.h
+++ b/CareKit/Utilities/OCKHelpers.h
@@ -191,6 +191,8 @@ NSDate *OCKDateFromStringISO8601(NSString *string);
 
 NSString *OCKSignatureStringFromDate(NSDate *date);
 
+NSString *OCKShortStyleTimeStringFromDate(NSDate *date);
+
 NSURL *OCKCreateRandomBaseURL(void);
 
 CGFloat OCKExpectedLabelHeight(UILabel *label);

--- a/CareKit/Utilities/OCKHelpers.m
+++ b/CareKit/Utilities/OCKHelpers.m
@@ -112,6 +112,17 @@ NSString *OCKSignatureStringFromDate(NSDate *date) {
     return [__formatter stringFromDate:date];
 }
 
+NSString *OCKShortStyleTimeStringFromDate(NSDate *date) {
+    static NSDateFormatter *__formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        __formatter = [NSDateFormatter new];
+        __formatter.dateStyle = NSDateFormatterNoStyle;
+        __formatter.timeStyle = NSDateFormatterShortStyle;
+    });
+    return [__formatter stringFromDate:date];
+}
+
 UIColor *OCKRGBA(uint32_t x, CGFloat alpha) {
     CGFloat b = (x & 0xff) / 255.0f; x >>= 8;
     CGFloat g = (x & 0xff) / 255.0f; x >>= 8;


### PR DESCRIPTION
Changes:
1. Added new date time formatter for displaying short style time string values
2. Removed "cellBackgroundColor" property from the CustomActivityTableViewCell so that the color is populated based on the activity's "tintColor" property
3. Removed references to the deleted "cellBackgroundColor" property
4. Updated cell's valueLabel and updatedAtLabel appearance according to the wireframes

Screeshots: 
1. Updated cell appearance for the activities of type "assessment"
![simulator screen shot - iphone xr - 2019-01-13 at 18 24 31](https://user-images.githubusercontent.com/7054895/51082745-890b5a80-1761-11e9-88ef-b2eae8ce6bc9.png)

